### PR TITLE
Allow passing source as a dictionary

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,24 @@ template = {
 t = Transformer(template)
 t(source) # {'name': 'Hassan Ali', 'years_old': '21 years old'}
 ```
+
+### Pass source as a dictionary ###
+You can also pass source attribute as a dictionary 
+```python
+from transformer import Transformer
+
+sourceDict = {
+            "first_name": "Hassan",
+            "last_name": "Ali",
+            "age": 21
+        }
+
+template = {
+            'name': '${first_name} + " " + ${last_name}',
+            'years_old': '"%d years old" %${age}'
+        }
+t = Transformer(template)
+t(sourceDict) # {'name': 'Hassan Ali', 'years_old': '21 years old'}
+```
+In the above code the sourceDict is a dictionary which contains the values to be substituted in the template
+

--- a/test.py
+++ b/test.py
@@ -10,6 +10,11 @@ class TestBasicDictTemplates(unittest.TestCase):
                 self.last_name = "Ali"
                 self.age = 21
         self.source = Foo()
+        self.sourceDict = {
+            "first_name": "Hassan",
+            "last_name": "Ali",
+            "age": 21
+        }
 
     def testSimpleValues(self):
         template = {
@@ -47,6 +52,45 @@ class TestBasicDictTemplates(unittest.TestCase):
         t = Transformer(template)
         with self.assertRaises(Exception):
             t(self.source)
+
+    
+    def testDictSimpleValues(self):
+        template = {
+            'foo': 'bar',
+            'first_name': 'Ahmed',
+            'last_name': 'Gamal',
+            'age': 31
+        }
+        t = Transformer(template=template)
+        self.assertEqual(t(self.sourceDict), template)
+
+    def testDictCalculatedValues(self):
+        template = {
+            'name': '${first_name} + " " + ${last_name}',
+            'years_old': '"%d years old" %${age}'
+        }
+        t = Transformer(template)
+        self.assertEqual(t(self.sourceDict), {'name': 'Hassan Ali', 'years_old': '21 years old'})
+
+
+    def testDictWrongTemplateAttributes(self):
+        template = {
+            'name': '${first_name} + " " + ${not_attribute}',
+            'age': '${age}'
+        }
+        t = Transformer(template)
+        with self.assertRaises(Exception):
+            t(self.sourceDict)
+    
+
+    def testDictWrongTemplates(self):
+        template = {
+            'name': '+ 1 ${age}', #invalid python syntax
+            'age': '${age}'
+        }
+        t = Transformer(template)
+        with self.assertRaises(Exception):
+            t(self.sourceDict)
 
 
 if __name__ == '__main__':

--- a/transformer/transformer.py
+++ b/transformer/transformer.py
@@ -1,7 +1,13 @@
 import re
+from collections import namedtuple
 
 
 class Transformer(object):
+    def to_obj(self, template):
+        dict_obj = template
+        return_obj = namedtuple("Object", dict_obj.keys())(*dict_obj.values())
+        return return_obj
+
     def __init__(self, template):
         self.template = template
 
@@ -28,6 +34,8 @@ class Transformer(object):
 
     def __call__(self, source):
         target = dict()
+        if type(source) is dict:
+            source = self.to_obj(source)
         for key in self.template:
             key_formatter = self.template[key]
             matched_placeholders = False


### PR DESCRIPTION
This PR is created to extend transformer class features. __call__ function now can receive a dictionary object which means that the client will be able to just pass a dictionary contains the values to be substituted.

Let me know your comments about this PR